### PR TITLE
Fix nonlinear transformations

### DIFF
--- a/pathflow_mixmatch/cli.py
+++ b/pathflow_mixmatch/cli.py
@@ -145,7 +145,10 @@ def affine_register(im1, im2, iterations=1000, lr=0.01, transform_type='similari
 		if transform_type == 'non_parametric':
 			transform_args[0]=mov_im_level[0].size
 		elif transform_type in ['bspline','wendland']:
-			transform_opts['sigma'] = (11, 11)
+			# for wendland, sigma must be positive tuple of ints
+			# for wendland, smaller sigma tuple means less loss of
+			# microarchitectural details
+			transform_opts['sigma'] = (1, 1)
 
 		transformation = transforms[transform_type](*transform_args,**transform_opts)
 

--- a/pathflow_mixmatch/cli.py
+++ b/pathflow_mixmatch/cli.py
@@ -143,20 +143,22 @@ def affine_register(im1, im2, iterations=1000, lr=0.01, transform_type='similari
 
 		# choose the affine transformation model
 		if transform_type == 'non_parametric':
-			transform_args[0]=mov_im_level[0].size
+			transform_args[0]=mov_im_level[level].size
 		elif transform_type in ['bspline','wendland']:
-			# for wendland, sigma must be positive tuple of ints
-			# for wendland, smaller sigma tuple means less loss of
+			# for bspline, sigma must be positive tuple of ints
+			# for bspline, smaller sigma tuple means less loss of
 			# microarchitectural details
+
+			# transform_opts['sigma'] = sigma[level]
 			transform_opts['sigma'] = (1, 1)
 
 		transformation = transforms[transform_type](*transform_args,**transform_opts)
 
-		if level > 0 and transform_type=='bspline':
-			constant_flow = al.transformation.utils.upsample_displacement(constant_flow,
-																		  mov_im_level.size,
-																		  interpolation=interpolation)
-			transformation.set_constant_flow(constant_flow)
+		# if level > 0 and transform_type=='bspline':
+		# 	constant_flow = al.transformation.utils.upsample_displacement(constant_flow,
+		# 																  mov_im_level.size,
+		# 																  interpolation=interpolation)
+		# 	transformation.set_constant_flow(constant_flow)
 
 		if transform_type in ['similarity', 'affine', 'rigid']:
 			# initialize the translation with the center of mass of the fixed image

--- a/pathflow_mixmatch/cli.py
+++ b/pathflow_mixmatch/cli.py
@@ -145,9 +145,7 @@ def affine_register(im1, im2, iterations=1000, lr=0.01, transform_type='similari
 		if transform_type == 'non_parametric':
 			transform_args[0]=mov_im_level[0].size
 		elif transform_type in ['bspline','wendland']:
-			transform_args[0]=mov_im_level.size
-			# transform_args[0]=tuple(mov_im_level.size)
-			# transform_opts['sigma'] = (11, 11, 3)
+			transform_opts['sigma'] = (11, 11)
 
 		transformation = transforms[transform_type](*transform_args,**transform_opts)
 
@@ -200,9 +198,9 @@ def affine_register(im1, im2, iterations=1000, lr=0.01, transform_type='similari
 	print("=================================================================")
 
 	print("Registration done in:", end - start, "s")
-	if transform_type != 'non_parametric':
+	if transform_type in ['similarity', 'affine', 'rigid']:
 		print("Result parameters:")
-		transformation.print()  # only works with rigid?
+		transformation.print()
 
 	# plot the results
 	plt.subplot(131)
@@ -217,9 +215,7 @@ def affine_register(im1, im2, iterations=1000, lr=0.01, transform_type='similari
 	plt.imshow(warped_image.numpy(), cmap='gray')
 	plt.title('Warped Moving Image')
 
-	if transform_type == 'similarity' or transform_type == 'affine' or transform_type == 'rigid':
-		# TODO: check if transformation has parent class
-		# airlab.transformation.pairwise.RigidTransformation
+	if transform_type in ['similarity', 'affine', 'rigid']:
 		transformation_param = transformation._phi_z
 	elif transform_type == 'non_parametric':
 		transformation_param = transformation.trans_parameters

--- a/pathflow_mixmatch/cli.py
+++ b/pathflow_mixmatch/cli.py
@@ -187,8 +187,8 @@ def affine_register(im1, im2, iterations=1000, lr=0.01, transform_type='similari
 		# start the registration
 		registration.start()
 
-		if transform_type == 'bspline':
-			constant_flow = transformation.get_flow()
+		# if transform_type == 'bspline':
+		# 	constant_flow = transformation.get_flow()
 
 	# set the intensities back to the original for the visualisation
 	fixed_image.image = 1 - fixed_image.image


### PR DESCRIPTION
- `non_parametric`: functional
- `bspline`: functional
- `wendland`: functional

Decreasing the learning rate solves the issue of the loss of microarchitectural details (https://github.com/airlab-unibas/airlab/issues/26). Further experimentation with parameters may be necessary. 